### PR TITLE
feat(#1658): Add flag for hab installation

### DIFF
--- a/executor/eks/eks.go
+++ b/executor/eks/eks.go
@@ -185,6 +185,7 @@ func getPodObject(config map[string]interface{}, namespace string) *core.Pod {
 						{Name: "SD_BASE_COMMAND_PATH", Value: "/sd/commands/"},
 						{Name: "SD_TEMP", Value: "/opt/sd_tmp"},
 						{Name: "DOCKER_HOST", Value: "tcp"},
+						{Name: "SD_HAB_ENABLED", Value: "yes"},
 					},
 					Command: []string{"/opt/sd/launcher_entrypoint.sh"},
 					Args: []string{

--- a/executor/serverless/serverless.go
+++ b/executor/serverless/serverless.go
@@ -309,7 +309,8 @@ func getEnvVars(config map[string]interface{}) []*codebuild.EnvironmentVariable 
 		{Name: aws.String("UI"), Value: aws.String(config["uiUri"].(string))},
 		{Name: aws.String("TIMEOUT"), Value: aws.String(strconv.Itoa(config["buildTimeout"].(int)))},
 		{Name: aws.String("SDBUILDID"), Value: aws.String(strconv.Itoa(config["buildId"].(int)))},
-		{Name: aws.String("SD_NO_HAB"), Value: aws.String(strconv.FormatBool(true))},
+		{Name: aws.String("SD_HAB_ENABLED"), Value: aws.String("yes")},
+		{Name: aws.String("SD_AWS_INTEGRATION"), Value: aws.String("yes")},
 	}
 }
 


### PR DESCRIPTION
## Context

Habitat installation needs to be optional for the launcher

## Objective

This PR adds the flag `SD_HAB_ENABLED` to executors

## References

https://github.com/screwdriver-cd/launcher/pull/429

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
