### PR TITLE
feat: make binary aws lambda compatible

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - binary: aws-consumer-service
+  - binary: bootstrap
     # Build for Linux and OSX
     goos:
       - linux
@@ -11,6 +11,8 @@ builds:
       - amd64
     env:
       - CGO_ENABLED=0
+    tags:
+      - lambda.norpc
 archives:
   - format: binary
     name_template: "{{ .ProjectName}}_{{ .Os}}_{{ .Arch}}"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -15,7 +15,7 @@ jobs:
             - tidy: go mod tidy
             - gofmt: (! gofmt -d -s . | grep '^')
             - test: make test JSONFILE=${SD_ARTIFACTS_DIR}/report.json COVERPROFILE=${SD_ARTIFACTS_DIR}/coverage.out
-            - build: go build -a -o /dev/null
+            - build: go build -tags lambda.norpc -a -o /dev/null
             - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
 
     publish:


### PR DESCRIPTION
## Context

We need to build the go binary with tags and with name `bootstrap`

## Objective

This PR builds the binary with tags and with the name `bootstrap`

## References

https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
